### PR TITLE
fix: register 8 missing fleet coordination MCP tools, fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ graph LR
 | Language | Splitting method | Support level |
 |----------|-----------------|---------------|
 | Python, TypeScript, JavaScript | AST-aware | Tier 1: functions, classes, methods |
-| Go, Rust | AST-aware | Tier 2: functions, types, impl blocks |
+| Go | AST-aware | Tier 2: functions, methods, types |
+| Rust | AST-aware | Tier 2: functions, impl blocks, structs, enums, traits |
 | All other languages | Text-only | Fallback: sliding window (2500 chars, 300 overlap) |
 
 AST-aware splitting means search results are complete, meaningful code units. Text-only fallback still works but may return partial functions. Adding a new language requires defining its tree-sitter node types in `fleet_mem/splitter/ast_splitter.py` (contributions welcome).
@@ -401,7 +402,7 @@ All settings via environment variables or a `.env` file in the project root. Cop
 | `MEMORY_DB_PATH` | `~/.local/share/fleet-mem/memory.db` | Agent memory database |
 | `FLEET_DB_PATH` | `~/.local/share/fleet-mem/fleet.db` | Fleet coordination database |
 | `SYNC_INTERVAL` | `300` | Background code index sync (seconds) |
-| `MCP_SETTINGS_FILE` | `~/.claude/settings.json` | MCP client settings path |
+| `FILE_WATCHING` | `true` | Enable filesystem watching for near-instant sync |
 
 <br>
 
@@ -414,7 +415,7 @@ All settings via environment variables or a `.env` file in the project root. Cop
 | **Lock acquire/release** | Immediate | Direct SQLite write |
 | **Notifications** | Immediate | Created on `memory_store` if subscriptions match |
 
-For fast-moving multi-agent work, reduce `SYNC_INTERVAL` to `30`-`60`. File-watching is also available for near-instant sync — set `WATCH_ENABLED=true` to detect changes immediately without polling.
+For fast-moving multi-agent work, reduce `SYNC_INTERVAL` to `30`-`60`. File-watching is also available for near-instant sync — set `FILE_WATCHING=true` (the default) to detect changes immediately without polling.
 
 <br>
 
@@ -607,7 +608,7 @@ fleet_stats() -> {
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
-| `memory_store` | `node_type, content, agent_id?` | Store a memory with optional file anchor |
+| `memory_store` | `node_type, content, summary?, keywords?, file_path?, line_range?, source?, project_path?` | Store a memory with optional file anchor |
 | `memory_search` | `query, top_k?, node_type?` | Hybrid keyword + semantic memory search |
 | `memory_promote` | `memory_id, target_scope?` | Promote a project memory to global scope |
 | `stale_check` | `project_path?` | Find memories whose anchored files have changed |
@@ -631,7 +632,7 @@ fleet_stats() -> {
 
 <br>
 
-### Status and observability (5 tools)
+### Status and observability (7 tools)
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
@@ -640,6 +641,8 @@ fleet_stats() -> {
 | `get_branches` | `path` | List indexed branches with chunk counts |
 | `cleanup_branch` | `path, branch` | Drop a branch overlay after merge |
 | `fleet_stats` | | Current metrics: chunks, memories, locks, cache hits, notifications |
+| `reconcile` | `path` | Remove ghost chunks whose source files no longer exist |
+| `clear_embedding_cache` | | Clear the embedding vector cache, forcing re-embedding on next use |
 
 ---
 

--- a/fleet_mem/server.py
+++ b/fleet_mem/server.py
@@ -906,6 +906,188 @@ async def fleet_agents() -> list[dict[str, Any]]:
 
 
 # ---------------------------------------------------------------------------
+# Tool: lock_acquire
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(
+    description="Declare files an agent is working on. Returns conflict info "
+    "if another agent holds overlapping locks."
+)
+async def lock_acquire(
+    agent_id: str,
+    project: str,
+    file_patterns: list[str],
+    branch: str = "main",
+    ttl_minutes: int = 60,
+) -> dict[str, Any]:
+    """Acquire file locks for an agent on a project."""
+    from .fleet.lock_registry import lock_acquire as _lock_acquire
+
+    cfg = _get_config()
+    return _lock_acquire(
+        db_path=cfg.fleet_db_path,
+        agent_id=agent_id,
+        project=project,
+        file_patterns=file_patterns,
+        branch=branch,
+        ttl_minutes=ttl_minutes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: lock_release
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(description="Release all file locks for an agent on a project.")
+async def lock_release(
+    agent_id: str,
+    project: str,
+) -> dict[str, Any]:
+    """Release file locks."""
+    from .fleet.lock_registry import lock_release as _lock_release
+
+    cfg = _get_config()
+    return _lock_release(
+        db_path=cfg.fleet_db_path,
+        agent_id=agent_id,
+        project=project,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: lock_query
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(description="Check who holds locks on which files in a project.")
+async def lock_query(
+    project: str,
+    file_path: str | None = None,
+) -> dict[str, Any]:
+    """List active locks, optionally filtered by file path."""
+    from .fleet.lock_registry import lock_query as _lock_query
+
+    cfg = _get_config()
+    return _lock_query(
+        db_path=cfg.fleet_db_path,
+        project=project,
+        file_path=file_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: merge_impact
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(description="Preview which agents, memories, and branches are affected by a merge.")
+async def merge_impact(
+    project: str,
+    files: list[str],
+) -> dict[str, Any]:
+    """Read-only merge impact preview."""
+    from .fleet.merge_impact import merge_impact as _merge_impact
+
+    cfg = _get_config()
+    return _merge_impact(
+        project=project,
+        files=files,
+        fleet_db_path=cfg.fleet_db_path,
+        memory_db_path=cfg.memory_db_path,
+        chroma_path=Path(cfg.chroma_path),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: notify_merge
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(description="Post-merge: notify affected agents and mark stale context.")
+async def notify_merge(
+    project: str,
+    branch: str,
+    merged_files: list[str],
+) -> dict[str, Any]:
+    """Notify subscribed agents after a merge and identify stale anchors."""
+    from .fleet.merge_impact import notify_merge as _notify_merge
+
+    cfg = _get_config()
+    return _notify_merge(
+        project=project,
+        branch=branch,
+        merged_files=merged_files,
+        fleet_db_path=cfg.fleet_db_path,
+        memory_db_path=cfg.memory_db_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: memory_feed
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(description="Recent memories from other agents.")
+async def memory_feed(
+    agent_id: str | None = None,
+    since_minutes: int = 60,
+) -> list[dict[str, Any]]:
+    """Query recent memory entries from other agents."""
+    from .fleet.cross_agent import memory_feed as _memory_feed
+
+    cfg = _get_config()
+    return _memory_feed(
+        memory_db_path=cfg.memory_db_path,
+        agent_id=agent_id,
+        since_minutes=since_minutes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: memory_subscribe
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(description="Subscribe to memories about specific file patterns.")
+async def memory_subscribe(
+    agent_id: str,
+    file_patterns: list[str],
+    project: str | None = None,
+) -> list[dict[str, Any]]:
+    """Create subscriptions for file pattern notifications."""
+    from .fleet.cross_agent import memory_subscribe as _memory_subscribe
+
+    cfg = _get_config()
+    return _memory_subscribe(
+        fleet_db_path=cfg.fleet_db_path,
+        agent_id=agent_id,
+        project=project or "default",
+        file_patterns=file_patterns,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool: memory_notifications
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool(description="Check for new relevant memories from other agents.")
+async def memory_notifications(
+    agent_id: str,
+) -> list[dict[str, Any]]:
+    """Return unread notifications for an agent, marking them as read."""
+    from .fleet.cross_agent import memory_notifications as _memory_notifications
+
+    cfg = _get_config()
+    return _memory_notifications(
+        fleet_db_path=cfg.fleet_db_path,
+        agent_id=agent_id,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Tool: get_fleet_stats
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Register 8 fleet coordination tools (`lock_acquire`, `lock_release`, `lock_query`, `merge_impact`, `notify_merge`, `memory_feed`, `memory_subscribe`, `memory_notifications`) as MCP tools in `server.py` — backend was implemented and tested but never wired up, making core advertised features unreachable
- Fix README: wrong env var (`WATCH_ENABLED` → `FILE_WATCHING`), non-existent `MCP_SETTINGS_FILE` config, wrong `memory_store` params, undocumented tools (`reconcile`, `clear_embedding_cache`), inaccurate Go/Rust language support descriptions

Closes #10
Closes #11

## Validation

- `from fleet_mem.server import mcp` → 27 tools registered (was 19)
- 33 fleet coordination tests pass (`test_lock_registry`, `test_cross_agent`, `test_merge_impact`, `test_sessions`)
- `ruff check` + `ruff format --check` clean

## Test plan

- [x] All 8 new tool wrappers verified present via import inspection
- [x] Existing fleet tests pass (33 passed in 0.67s)
- [x] Lint clean
- [x] README entries cross-checked against `config.py` and `server.py` signatures